### PR TITLE
Commands with camera list

### DIFF
--- a/zoom_kurokesu/zoom_piloting.py
+++ b/zoom_kurokesu/zoom_piloting.py
@@ -157,6 +157,48 @@ class ZoomController:
             self.ser.write(bytes(command + '\n', 'utf8'))
             _ = self.ser.readline()
 
+    def multiple_synchronous_homing(self, camera: list) -> None:
+        """Use serial port to perform homing sequence on cameras in camera list.
+
+        Args:
+            camera: string list, can contain "left" and/or "right" values
+        """
+        zoom1 = []
+        zoom2 = []
+        focus1 = []
+
+        command = 'G92 '
+
+        success = True
+        for i in range(len(camera)):
+            try:
+                mot = self.motors[self.connector[camera[i]]]
+            except KeyError:
+                success = False
+                raise ValueError(camera[i] + " camera name doesn't exist")
+            command += mot['zoom'] + '0 ' + mot['focus'] + '0 '
+            zoom1.append(0)
+            focus1.append(-500)
+            zoom2.append(-600)
+
+        if success:
+            try:
+
+                self.ser.write(bytes(command + '\n', 'utf8'))
+                _ = self.ser.readline()
+                time.sleep(0.1)
+            except Exception as e:
+                print(e)
+
+            self.send_synchronous_custom_commands(camera, zoom1, focus1)
+            time.sleep(1)
+            self.send_synchronous_custom_commands(camera, zoom2, focus1)
+            time.sleep(1)
+
+            self.ser.write(bytes(command + '\n', 'utf8'))
+            _ = self.ser.readline()
+            time.sleep(0.1)
+
     def homing(self, side: str) -> None:
         """Use serial port to perform homing sequence on given camera.
 

--- a/zoom_kurokesu/zoom_piloting.py
+++ b/zoom_kurokesu/zoom_piloting.py
@@ -131,13 +131,15 @@ class ZoomController:
 
         Given as many zoom and focus value as name in camera list,
         produce the corresponding G-code and send it over the serial port.
-        motors will move at once
-        zoom and focus at index i refer to camera at index i in list
+        Motors will move at once
+        Zoom and focus at index i refer to camera at index i in list
+        Give -1 value in focus or zoom list to not move
+        Zoom and focus list can contain both int and string values. 
 
         Args:
             camera: string list, can contain "left" and/or "right" value
-            zoom: int list between 0 and 600
-            zoom: int list between 0 and 600
+            zoom: list, can contain int value between -1 and 600 or focus/zoom level among 'in', 'inter' or 'out'
+            focus: list, can contain int value between -1 and 500 or focus/zoom level among 'in', 'inter' or 'out'
         """
         command = 'G1'
         if (len(camera) != len(zoom) or len(camera) != len(focus)):
@@ -150,7 +152,17 @@ class ZoomController:
             except KeyError:
                 success = False
                 raise ValueError(camera[i] + " camera name doesn't exist")
-            command += f' {mot["zoom"]}{zoom[i]} {mot["focus"]}{focus[i]} '
+
+            if focus[i] != -1:
+                if focus[i] in {"in", "inter", "out"}:
+                    command += f' {mot["focus"]}{self.zoom_pos[camera[i]][focus[i]]["focus"]} '
+                else:
+                    command += f' {mot["focus"]}{focus[i]} '
+            if zoom[i] != -1:
+                if zoom[i] in {"in", "inter", "out"}:
+                    command += f' {mot["zoom"]}{self.zoom_pos[camera[i]][zoom[i]]["zoom"]} '
+                else :
+                    command += f' {mot["zoom"]}{zoom[i]} '
 
         if success:
             command += f'F{self.speed}'

--- a/zoom_kurokesu/zoom_piloting.py
+++ b/zoom_kurokesu/zoom_piloting.py
@@ -126,6 +126,37 @@ class ZoomController:
         self.ser.write(bytes(command + '\n', 'utf8'))
         _ = self.ser.readline()
 
+    def send_synchronous_custom_commands(self, camera: list, zoom: list, focus: list):
+        """Send custom zoom and focus values to multiple cameras.
+
+        Given as many zoom and focus value as name in camera list,
+        produce the corresponding G-code and send it over the serial port.
+        motors will move at once
+        zoom and focus at index i refer to camera at index i in list
+
+        Args:
+            camera: string list, can contain "left" and/or "right" value
+            zoom: int list between 0 and 600
+            zoom: int list between 0 and 600
+        """
+        command = 'G1'
+        if (len(camera) != len(zoom) or len(camera) != len(focus)):
+            raise ValueError('list objects must have same size')
+
+        success = True
+        for i in range(len(camera)):
+            try:
+                mot = self.motors[self.connector[camera[i]]]
+            except KeyError:
+                success = False
+                raise ValueError(camera[i] + " camera name doesn't exist")
+            command += f' {mot["zoom"]}{zoom[i]} {mot["focus"]}{focus[i]} '
+
+        if success:
+            command += f'F{self.speed}'
+            self.ser.write(bytes(command + '\n', 'utf8'))
+            _ = self.ser.readline()
+
     def homing(self, side: str) -> None:
         """Use serial port to perform homing sequence on given camera.
 


### PR DESCRIPTION
Global methods allowing to control Zoom and Focus of a list of cameras at once.

--
Should those methods replace send_zoom_command_two_cameras, send_custom_zoom_two_cameras, send_custom_focus_two_cameras,  In the end?